### PR TITLE
[ENG-1196] Add reusable workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,114 @@
-# oak-release-actions 
+# oak-release-actions
+
+It houses a collection of reusable GitHub Actions for Terraform‑controlled applications. Any repository can call these actions to:
+- Preview proposed infrastructure changes on `PRs`
+- Deploy automatically to environments on new semantic version tags
+- Promote a specific release to `production` by inputting a `tag_id`
+
+#### Structure
+
+```plaintext
+.github/
+└── actions/
+    ├── terraform_deploy
+    │   └── action.yml      # Deployment: on 'v*' tags or Production Promotion: manual workflow_dispatch
+    └── terraform_pr_plan
+        └── action.yml      # Plan Phase: Terraform plan on PR
+```
+
+#### Key Features
+
+- **Plan Phase (Pull Request)**
+ Runs terraform plan in Terraform Cloud and comments the plan link on the PR for easy review.
+- **Terraform Deploy**
+ Handles both automatic deployments to environments like beta on semantic tag pushes (v*) and manual promotions to production using a workflow_dispatch with a tag_id.
+
+### How to Use
+
+1. **Plan Phase (Pull Request)**
+In your repo’s .github/workflows/pr_plan.yml:
+```yaml
+name: Terraform Plan Preview
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Terraform Plan from oak-release-actions
+        uses: oaknational/oak-release-actions/actions/terraform_pr_plan@main
+        with:
+            TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+            TF_BASE_SUBDIRECTORY: "folder-that-contains-your-terraform-files"
+            TF_CLOUD_ORGANIZATION: "your-terraform-cloud-organization"
+            TF_WORKSPACE: "your-workspace"
+            PR_COMMENT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+2. **Tag-Based Deployment(e.g beta)**
+In your repo’s .github/workflows/beta_deploy.yml:
+
+```yaml
+name: Terraform Deploy to Beta
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Terraform Apply from oak-release-actions
+        uses: oaknational/oak-release-actions/actions/terraform_deploy@main
+        with:
+            TAG_ID: ${{ github.ref_name }}
+            TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+            TF_BASE_SUBDIRECTORY: "folder-that-contains-your-terraform-files"
+            TF_CLOUD_ORGANIZATION: "your-terraform-cloud-organization"
+            TF_WORKSPACE: "your-workspace"
+```
+
+3. **Manual Production Promotion**
+In your repo’s .github/workflows/prod-promote.yml:
+
+```yaml
+name: Promote Terraform to Production
+on:
+  workflow_dispatch:
+    inputs:
+      tag_id:
+        description: 'Git tag to apply to production'
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.inputs.tag_id }}
+
+      - name: Run Terraform Deploy from oak-release-actions
+        uses: oaknational/oak-release-actions/actions/terraform_deploy@main
+        with:
+            TAG_ID: ${{  inputs.tag_id }}
+            TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+            TF_BASE_SUBDIRECTORY: "folder-that-contains-your-terraform-files"
+            TF_CLOUD_ORGANIZATION: "your-terraform-cloud-organization"
+            TF_WORKSPACE: "your-workspace"
+```

--- a/actions/terraform_deploy/action.yml
+++ b/actions/terraform_deploy/action.yml
@@ -1,0 +1,57 @@
+name: Terraform Cloud Apply 
+description: "Applies changes to environment"
+
+inputs:
+  TF_API_TOKEN:
+    required: true
+
+  TF_BASE_DIRECTORY:
+    default: "infrastructure"
+    
+  TF_BASE_SUBDIRECTORY:
+    required: true
+
+  TF_CLOUD_ORGANIZATION:
+    required: true
+
+  TF_WORKSPACE:
+      required: true
+
+  TAG_ID:
+    required: true
+
+
+runs:
+    using: "composite"
+    steps:
+      - name: Set global ENV vars
+        shell: bash
+        run: |
+          echo "TF_API_TOKEN=${{ inputs.TF_API_TOKEN }}" >> $GITHUB_ENV
+          echo "TF_CLOUD_ORGANIZATION=${{ inputs.TF_CLOUD_ORGANIZATION }}" >> $GITHUB_ENV
+
+      - name: Set TF_VAR_tag_id
+        shell: bash
+        run: |
+          echo "TF_VAR_tag_id=\"${{ inputs.TAG_ID }}\""  >> $GITHUB_ENV
+
+      - name: Upload Configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
+        id: apply-upload
+        with:
+          workspace: ${{ inputs.TF_WORKSPACE }}
+          directory: ${{ inputs.TF_BASE_DIRECTORY }}/${{ inputs.TF_BASE_SUBDIRECTORY }}
+
+      - name: Create Apply Run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.0
+        id: apply-run
+        with:
+          workspace: ${{ inputs.TF_WORKSPACE }}
+          configuration_version: ${{ steps.apply-upload.outputs.configuration_version_id }}
+
+      - name: Apply
+        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.0.0
+        with:
+          run: ${{ steps.apply-run.outputs.run_id }}
+          comment: "Applied GitHub Actions CI ${{ github.sha }}"
+    

--- a/actions/terraform_pr_plan/action.yml
+++ b/actions/terraform_pr_plan/action.yml
@@ -1,0 +1,96 @@
+name: Terraform Plan Preview
+description: "Runs terraform plan when a PR is created"
+
+inputs:
+  PR_COMMENT_TOKEN:
+    required: true
+  
+  TF_API_TOKEN:
+    required: true
+
+  TF_BASE_DIRECTORY:
+    default: "infrastructure"
+    
+  TF_BASE_SUBDIRECTORY:
+    required: true
+
+  TF_CLOUD_ORGANIZATION:
+    required: true
+
+  TF_WORKSPACE:
+      required: true
+
+runs:
+    using: "composite"
+    steps:
+      - name: Set global ENV vars
+        shell: bash
+        run: |
+          echo "TF_API_TOKEN=${{ inputs.TF_API_TOKEN }}" >> $GITHUB_ENV
+          echo "TF_CLOUD_ORGANIZATION=${{ inputs.TF_CLOUD_ORGANIZATION }}" >> $GITHUB_ENV
+          
+      - name: Set tag_id for PRs
+        shell: bash
+        run: | 
+          echo "TF_VAR_tag_id=\"pr-preview\"" >> $GITHUB_ENV
+          echo "Set TF_VAR_tag_id to pr-preview for PR run"
+
+      - name: Upload Configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
+        id: plan-upload
+        with:
+          workspace: ${{ inputs.TF_WORKSPACE }}
+          directory: ${{ inputs.TF_BASE_DIRECTORY }}/${{ inputs.TF_BASE_SUBDIRECTORY }}
+          speculative: true
+
+      - name: Create Plan Run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.0
+        id: plan-run
+        env:
+          TF_API_TOKEN: ${{ inputs.TF_API_TOKEN }}
+        with:
+          organization: ${{ inputs.TF_CLOUD_ORGANIZATION }}
+          workspace: ${{ inputs.TF_WORKSPACE }}
+          configuration_version: ${{ steps.plan-upload.outputs.configuration_version_id }}
+          plan_only: true
+
+      - name: Get Plan Output
+        uses: hashicorp/tfc-workflows-github/actions/plan-output@v1.0.0
+        id: plan-output
+        with:
+          plan: ${{ fromJSON(steps.plan-run.outputs.payload).data.relationships.plan.data.id }}
+
+      - name: Update PR
+        uses: actions/github-script@v6
+        id: plan-comment
+        with:
+          github-token: ${{ inputs.PR_COMMENT_TOKEN }}
+          script: |
+            const prParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            };
+
+            const { data: comments } = await github.rest.issues.listComments(prParams);
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes('Terraform Plan Output')
+            );
+
+            const output = `#### Terraform Plan Output
+              \`\`\`
+              Plan: ${{ steps.plan-output.outputs.add }} to add, ${{ steps.plan-output.outputs.change }} to change, ${{ steps.plan-output.outputs.destroy }} to destroy.
+              \`\`\`
+              [Terraform Plan](${{ steps.plan-run.outputs.run_link }})`;
+
+            if (botComment) {
+               github.rest.issues.deleteComment({
+                ...prParams,
+                comment_id: botComment.id,
+              });
+            }
+
+            github.rest.issues.createComment({
+              ...prParams,
+              body: output
+            });


### PR DESCRIPTION

## Description
This adds reusable workflows that does the following:
- PR Plan Preview – runs terraform plan in Terraform Cloud on pull requests and posts the plan link as a PR comment.
- Beta Deploy – triggers on semantic version tags (v*) to apply changes to the beta workspace.
- Prod Promote – manual workflow_dispatch accepting a tag_id to apply a specific release to production.

## Issue(s)

[ENG-1196](https://www.notion.so/oaknationalacademy/Implement-reusable-workflows-in-new-release-actions-repo-1db26cc4e1b1805295fae65612b071b5)

## How to test

1. Create a feature branch off this branch to test

Pr plan preview example: https://github.com/oaknational/oak-pupil-api/pull/26#:~:text=Terraform%20Plan%20Output,Terraform%20Plan

## Checklist

- [ ] nil
